### PR TITLE
fix: unload hooks on plugin unload

### DIFF
--- a/SharpTimer.cs
+++ b/SharpTimer.cs
@@ -395,18 +395,7 @@ namespace SharpTimer
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && disableDamage == true)
             {
-                VirtualFunctions.CBaseEntity_TakeDamageOldFunc.Hook((h =>
-                {
-                    if (disableDamage == false || h == null) return HookResult.Continue;
-
-                    var damageInfoParam = h.GetParam<CTakeDamageInfo>(1);
-
-                    if (damageInfoParam == null) return HookResult.Continue;
-
-                    if (disableDamage == true) damageInfoParam.Damage = 0;
-
-                    return HookResult.Continue;
-                }), HookMode.Pre);
+                VirtualFunctions.CBaseEntity_TakeDamageOldFunc.Hook(this.OnTakeDamage, HookMode.Pre);
             }
             else
             {
@@ -414,6 +403,26 @@ namespace SharpTimer
             }
 
             SharpTimerDebug("Plugin Loaded");
+        }
+
+        public override void Unload(bool hotReload)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && disableDamage == true)
+            {
+                VirtualFunctions.CBaseEntity_TakeDamageOldFunc.Unhook(this.OnTakeDamage, HookMode.Pre);
+            }
+        }
+
+        private HookResult OnTakeDamage(dynamic h) {
+            if (disableDamage == false || h == null) return HookResult.Continue;
+
+            var damageInfoParam = h.GetParam<CTakeDamageInfo>(1);
+
+            if (damageInfoParam == null) return HookResult.Continue;
+
+            if (disableDamage == true) damageInfoParam.Damage = 0;
+
+            return HookResult.Continue;
         }
     }
 }


### PR DESCRIPTION
Properly unload hooks on plugin unload

PS : You have a problem in this file about your EOL, it uses CRLF instead of LF